### PR TITLE
fix github & steam links

### DIFF
--- a/pages/scams/steam-gift-card.mdx
+++ b/pages/scams/steam-gift-card.mdx
@@ -12,7 +12,7 @@
 
 ## How do I avoid this scam?
 - Don't click on any links from people you don't know
-- Don't login to any site that isn't `https://store.steampowered.com` or `https://steamcommunity.com`
+- Don't login to any site that isn't `https://store.steampowered.com/login` or `https://steamcommunity.com/login`
 - Don't give out your login credentials to anyone
 - Do you know the user? If not, don't interact
 

--- a/pages/scams/steam-gift-card.mdx
+++ b/pages/scams/steam-gift-card.mdx
@@ -12,7 +12,7 @@
 
 ## How do I avoid this scam?
 - Don't click on any links from people you don't know
-- Don't login to any site that isn't `https://store.steampowered.com`
+- Don't login to any site that isn't `https://store.steampowered.com` or `https://steamcommunity.com`
 - Don't give out your login credentials to anyone
 - Do you know the user? If not, don't interact
 

--- a/theme.config.js
+++ b/theme.config.js
@@ -18,9 +18,9 @@ import {
 /** @type {import('nextra-theme-docs').DocsThemeConfig} */
 const themeConfig = {
   project: {
-    link: "https://github.com/NoTextToSpeech/ntts-site",
+    link: "https://github.com/NoTextToSpeech/website",
   },
-  docsRepositoryBase: "https://github.com/NoTextToSpeech/ntts-site/blob/main",
+  docsRepositoryBase: "https://github.com/NoTextToSpeech/website/blob/main",
   useNextSeoProps() {
     return {
       titleTemplate: "%s – NTTS",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the instructions below.


### New page 📚

- Created default English translation (`.en-US`) page
- Add translation pages for all other languages (no need to translate them but copy from the original one)

### Updating existing pages ✍️

- Update it in all other languages if it's code example (Use English if you don't know how to translate)


🎉🎉🎉 Thanks for your contribution! 🎉🎉🎉

-->

### Description

<!-- What're you changing? -->

- [ ] Adding new page
- [x] Updating existing documentation
- [x] Other updates

I changed the links directing to the GitHub repository to this one instead of the old one & I changed the the "Steam Scam" page to also include steamcommunity.com as you can log in through both sites(see attachments).
<img width="806" alt="image" src="https://github.com/user-attachments/assets/6eadd09f-25ae-4705-8511-23e2b5f1e2c1">
<img width="799" alt="image" src="https://github.com/user-attachments/assets/70a36f27-735c-4f45-8bd2-5a895a08be33">
